### PR TITLE
Make `starBorderWidth` and `starCornerRadius` dimensions instead of floats.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
+    classpath 'com.android.tools.build:gradle:3.1.3'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
   }
@@ -14,8 +14,8 @@ buildscript {
 
 allprojects {
   repositories {
-    jcenter()
     google()
+    jcenter()
     maven { url 'https://jitpack.io' }
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/simpleratingbar-sample/build.gradle
+++ b/simpleratingbar-sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.0"
+  buildToolsVersion "28.0.0"
 
   defaultConfig {
     applicationId "com.example.simpleratingbar"
@@ -28,8 +28,8 @@ android {
 
 dependencies {
   implementation project(':simpleratingbar')
-  implementation 'com.android.support:appcompat-v7:27.1.0'
-  implementation 'com.android.support:design:27.1.0'
+  implementation 'com.android.support:appcompat-v7:27.1.1'
+  implementation 'com.android.support:design:27.1.1'
   // Material colors
   implementation 'com.github.mcginty:material-colors:1.1.0'
   // Butterknife

--- a/simpleratingbar-sample/src/main/res/layout/fragment_border_width.xml
+++ b/simpleratingbar-sample/src/main/res/layout/fragment_border_width.xml
@@ -23,7 +23,7 @@
         app:srb_borderColor="@color/material_red500"
         app:srb_pressedFillColor="@color/material_redA200"
         app:srb_pressedBorderColor="@color/material_redA400"
-        app:srb_starBorderWidth="5"
+        app:srb_starBorderWidth="5dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -35,7 +35,7 @@
         app:srb_borderColor="@color/material_blue500"
         app:srb_pressedFillColor="@color/material_blueA200"
         app:srb_pressedBorderColor="@color/material_blueA400"
-        app:srb_starBorderWidth="6"
+        app:srb_starBorderWidth="6dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -47,7 +47,7 @@
         app:srb_borderColor="@color/material_green500"
         app:srb_pressedFillColor="@color/material_greenA700"
         app:srb_pressedBorderColor="@color/material_green700"
-        app:srb_starBorderWidth="7"
+        app:srb_starBorderWidth="7dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -59,7 +59,7 @@
         app:srb_borderColor="@color/material_amber500"
         app:srb_pressedFillColor="@color/material_amberA400"
         app:srb_pressedBorderColor="@color/material_amberA700"
-        app:srb_starBorderWidth="8"
+        app:srb_starBorderWidth="8dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -71,7 +71,7 @@
         app:srb_borderColor="@color/material_purple500"
         app:srb_pressedFillColor="@color/material_purpleA200"
         app:srb_pressedBorderColor="@color/material_purpleA400"
-        app:srb_starBorderWidth="9"
+        app:srb_starBorderWidth="9dp"
         />
 
   </LinearLayout>

--- a/simpleratingbar-sample/src/main/res/layout/fragment_border_width.xml
+++ b/simpleratingbar-sample/src/main/res/layout/fragment_border_width.xml
@@ -23,7 +23,7 @@
         app:srb_borderColor="@color/material_red500"
         app:srb_pressedFillColor="@color/material_redA200"
         app:srb_pressedBorderColor="@color/material_redA400"
-        app:srb_starBorderWidth="5dp"
+        app:srb_starBorderWidth="2dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -35,7 +35,7 @@
         app:srb_borderColor="@color/material_blue500"
         app:srb_pressedFillColor="@color/material_blueA200"
         app:srb_pressedBorderColor="@color/material_blueA400"
-        app:srb_starBorderWidth="6dp"
+        app:srb_starBorderWidth="3dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -47,7 +47,7 @@
         app:srb_borderColor="@color/material_green500"
         app:srb_pressedFillColor="@color/material_greenA700"
         app:srb_pressedBorderColor="@color/material_green700"
-        app:srb_starBorderWidth="7dp"
+        app:srb_starBorderWidth="4dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -59,7 +59,7 @@
         app:srb_borderColor="@color/material_amber500"
         app:srb_pressedFillColor="@color/material_amberA400"
         app:srb_pressedBorderColor="@color/material_amberA700"
-        app:srb_starBorderWidth="8dp"
+        app:srb_starBorderWidth="5dp"
         />
 
     <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -71,7 +71,7 @@
         app:srb_borderColor="@color/material_purple500"
         app:srb_pressedFillColor="@color/material_purpleA200"
         app:srb_pressedBorderColor="@color/material_purpleA400"
-        app:srb_starBorderWidth="9dp"
+        app:srb_starBorderWidth="6dp"
         />
 
   </LinearLayout>

--- a/simpleratingbar-sample/src/main/res/layout/fragment_corner_radius.xml
+++ b/simpleratingbar-sample/src/main/res/layout/fragment_corner_radius.xml
@@ -23,7 +23,7 @@
             app:srb_borderColor="@color/material_red500"
             app:srb_pressedFillColor="@color/material_redA200"
             app:srb_pressedBorderColor="@color/material_redA400"
-            app:srb_starCornerRadius="0"
+            app:srb_starCornerRadius="0dp"
             />
 
         <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -35,7 +35,7 @@
             app:srb_borderColor="@color/material_blue500"
             app:srb_pressedFillColor="@color/material_blueA200"
             app:srb_pressedBorderColor="@color/material_blueA400"
-            app:srb_starCornerRadius="2"
+            app:srb_starCornerRadius="2dp"
             />
 
         <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -47,7 +47,7 @@
             app:srb_borderColor="@color/material_green500"
             app:srb_pressedFillColor="@color/material_greenA700"
             app:srb_pressedBorderColor="@color/material_green700"
-            app:srb_starCornerRadius="4"
+            app:srb_starCornerRadius="4dp"
             />
 
         <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -59,7 +59,7 @@
             app:srb_borderColor="@color/material_amber500"
             app:srb_pressedFillColor="@color/material_amberA400"
             app:srb_pressedBorderColor="@color/material_amberA700"
-            app:srb_starCornerRadius="6"
+            app:srb_starCornerRadius="6dp"
             />
 
         <com.iarcuschin.simpleratingbar.SimpleRatingBar
@@ -71,7 +71,7 @@
             app:srb_borderColor="@color/material_purple500"
             app:srb_pressedFillColor="@color/material_purpleA200"
             app:srb_pressedBorderColor="@color/material_purpleA400"
-            app:srb_starCornerRadius="8"
+            app:srb_starCornerRadius="8dp"
             />
 
     </LinearLayout>

--- a/simpleratingbar/build.gradle
+++ b/simpleratingbar/build.gradle
@@ -26,7 +26,7 @@ ext {
 
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.0.0"
+  buildToolsVersion "28.0.0"
 
   defaultConfig {
     minSdkVersion 14
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-  api 'com.android.support:support-v4:27.0.1'
+  api 'com.android.support:support-v4:27.1.1'
 }
 
 apply from: 'installv1.gradle'

--- a/simpleratingbar/src/main/java/com/iarcuschin/simpleratingbar/SimpleRatingBar.java
+++ b/simpleratingbar/src/main/java/com/iarcuschin/simpleratingbar/SimpleRatingBar.java
@@ -186,8 +186,8 @@ public class SimpleRatingBar extends View {
     maxStarSize = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_maxStarSize, Integer.MAX_VALUE);
     desiredStarSize = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starSize, Integer.MAX_VALUE);
     stepSize = arr.getFloat(R.styleable.SimpleRatingBar_srb_stepSize, 0.1f);
-    starBorderWidth = arr.getFloat(R.styleable.SimpleRatingBar_srb_starBorderWidth, 5f);
-    starCornerRadius = arr.getFloat(R.styleable.SimpleRatingBar_srb_starCornerRadius, 6f);
+    starBorderWidth = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starBorderWidth, (int)valueToPixels(5, Dimension.DP));
+    starCornerRadius = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starCornerRadius, (int)valueToPixels(6, Dimension.DP));
 
     rating = normalizeRating(arr.getFloat(R.styleable.SimpleRatingBar_srb_rating, 0f));
     isIndicator = arr.getBoolean(R.styleable.SimpleRatingBar_srb_isIndicator, false);

--- a/simpleratingbar/src/main/java/com/iarcuschin/simpleratingbar/SimpleRatingBar.java
+++ b/simpleratingbar/src/main/java/com/iarcuschin/simpleratingbar/SimpleRatingBar.java
@@ -186,8 +186,8 @@ public class SimpleRatingBar extends View {
     maxStarSize = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_maxStarSize, Integer.MAX_VALUE);
     desiredStarSize = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starSize, Integer.MAX_VALUE);
     stepSize = arr.getFloat(R.styleable.SimpleRatingBar_srb_stepSize, 0.1f);
-    starBorderWidth = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starBorderWidth, (int)valueToPixels(5, Dimension.DP));
-    starCornerRadius = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starCornerRadius, (int)valueToPixels(6, Dimension.DP));
+    starBorderWidth = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starBorderWidth, (int)valueToPixels(2, Dimension.DP));
+    starCornerRadius = arr.getDimensionPixelSize(R.styleable.SimpleRatingBar_srb_starCornerRadius, (int)valueToPixels(3, Dimension.DP));
 
     rating = normalizeRating(arr.getFloat(R.styleable.SimpleRatingBar_srb_rating, 0f));
     isIndicator = arr.getBoolean(R.styleable.SimpleRatingBar_srb_isIndicator, false);

--- a/simpleratingbar/src/main/res/values/attr.xml
+++ b/simpleratingbar/src/main/res/values/attr.xml
@@ -13,8 +13,8 @@
     <attr name="srb_starSize" format="dimension" />
     <attr name="srb_maxStarSize" format="dimension" />
     <attr name="srb_starsSeparation" format="dimension" />
-    <attr name="srb_starBorderWidth" format="float" />
-    <attr name="srb_starCornerRadius" format="float" />
+    <attr name="srb_starBorderWidth" format="dimension" />
+    <attr name="srb_starCornerRadius" format="dimension" />
     <attr name="srb_isIndicator" format="boolean" />
     <attr name="srb_rating" format="float" />
     <attr name="srb_stepSize" format="float" />


### PR DESCRIPTION
Currently, `starBorderWidth` and `starCornerRadius` styleable attributes are floats that are treated as pixels, which gives different results depending on the device. This PR changes them to dimensions, so the star shape is consistent across devices.